### PR TITLE
Update build.gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,10 @@ dependencies {
     api wpi.deps.vendor.java()
 
     testImplementation 'org.hamcrest:hamcrest:2.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.0'
-    testImplementation 'org.mockito:mockito-core:2.+'
-    testImplementation 'org.mockito:mockito-junit-jupiter:2.26+'
-    testImplementation 'org.mockito:mockito-inline:2.26+'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.5.1'
+    testImplementation 'org.mockito:mockito-core:3.0.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.0.0'
+    testImplementation 'org.mockito:mockito-inline:3.0.0'
     testImplementation group: 'org.jfree', name: 'jfreechart', version: '1.5.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,12 +23,14 @@ repositories {
     jcenter()
 }
 
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
 dependencies {
     api wpi.deps.wpilib()
     api wpi.deps.vendor.java()
 
-    testImplementation 'org.hamcrest:hamcrest-core:1.3'
-    testImplementation 'org.hamcrest:hamcrest-integration:1.3'
+    testImplementation 'org.hamcrest:hamcrest:2.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.0'
     testImplementation 'org.mockito:mockito-core:2.+'
     testImplementation 'org.mockito:mockito-junit-jupiter:2.26+'

--- a/vendordeps/navx_frc.json
+++ b/vendordeps/navx_frc.json
@@ -1,33 +1,29 @@
 {
-    "fileName": "navx_frc.json",
-    "name": "KauaiLabs_navX_FRC",
-    "version": "3.1.367",
-    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
-    "mavenUrls": [
-        "https://repo1.maven.org/maven2/"
-    ],
-    "jsonUrl": "https://www.kauailabs.com/dist/frc/2019/navx_frc.json",
-    "javaDependencies": [
-        {
-            "groupId": "com.kauailabs.navx.frc",
-            "artifactId": "navx-java",
-            "version": "3.1.367"
-        }
-    ],
-    "jniDependencies": [],
-    "cppDependencies": [
-        {
-            "groupId": "com.kauailabs.navx.frc",
-            "artifactId": "navx-cpp",
-            "version": "3.1.367",
-            "headerClassifier": "headers",
-            "sourcesClassifier": "sources",
-            "sharedLibrary": false,
-            "libName": "navx_frc",
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "linuxathena"
-            ]
-        }
-    ]
+  "fileName": "navx_frc.json",
+  "name": "KauaiLabs_navX_FRC",
+  "version": "3.1.377",
+  "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+  "mavenUrls": ["https://repo1.maven.org/maven2/"],
+  "jsonUrl": "https://www.kauailabs.com/dist/frc/2019/navx_frc.json",
+  "javaDependencies": [
+    {
+      "groupId": "com.kauailabs.navx.frc",
+      "artifactId": "navx-java",
+      "version": "3.1.377"
+    }
+  ],
+  "jniDependencies": [],
+  "cppDependencies": [
+    {
+      "groupId": "com.kauailabs.navx.frc",
+      "artifactId": "navx-cpp",
+      "version": "3.1.377",
+      "headerClassifier": "headers",
+      "sourcesClassifier": "sources",
+      "sharedLibrary": false,
+      "libName": "navx_frc",
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": ["linuxathena", "linuxraspbian"]
+    }
+  ]
 }


### PR DESCRIPTION
Update `build.gradle` dependencies and enforce Java 11 source compatibility to make GradleRIO simulation integration better.
