### PR TITLE
Controller interface

### DIFF
--- a/src/main/java/com/pigmice/frc/lib/controllers/IController.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/IController.java
@@ -1,0 +1,6 @@
+package com.pigmice.frc.lib.controllers;
+
+public interface IController {
+    public void initialize(double input, double currentOutput);
+    public double calculateOutput(double input, double setpoint);
+}

--- a/src/main/java/com/pigmice/frc/lib/controllers/PID.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/PID.java
@@ -1,10 +1,9 @@
-package com.pigmice.frc.lib.pidf;
+package com.pigmice.frc.lib.controllers;
 
-import com.pigmice.frc.lib.controllers.IController;
 import com.pigmice.frc.lib.utils.Range;
 
-public class PIDF implements IController {
-    private Gains gains;
+public class PID implements IController {
+    private PIDGains gains;
     private final double period;
 
     private Range outputBounds;
@@ -17,7 +16,7 @@ public class PIDF implements IController {
     private double previousInput;
     private double previousError;
 
-    public PIDF(Gains gains, Range outputBounds, double period) {
+    public PID(PIDGains gains, Range outputBounds, double period) {
         this.gains = gains;
         this.period = period;
         this.outputBounds = outputBounds;

--- a/src/main/java/com/pigmice/frc/lib/controllers/PID.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/PID.java
@@ -3,7 +3,7 @@ package com.pigmice.frc.lib.controllers;
 import com.pigmice.frc.lib.utils.Range;
 
 public class PID implements IController {
-    private PIDGains gains;
+    private final PIDGains gains;
     private final double period;
 
     private Range outputBounds;

--- a/src/main/java/com/pigmice/frc/lib/controllers/PIDGains.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/PIDGains.java
@@ -1,14 +1,14 @@
-package com.pigmice.frc.lib.pidf;
+package com.pigmice.frc.lib.controllers;
 
-public class Gains {
+public class PIDGains {
     private double kP, kI, kD;
     private double kF, kV, kA;
 
-    public Gains(double kP, double kI, double kD) {
+    public PIDGains(double kP, double kI, double kD) {
         this(kP, kI, kD, 0.0, 0.0, 0.0);
     }
 
-    public Gains(double kP, double kI, double kD, double kF, double kV, double kA) {
+    public PIDGains(double kP, double kI, double kD, double kF, double kV, double kA) {
         this.kP = kP;
         this.kI = kI;
         this.kD = kD;

--- a/src/main/java/com/pigmice/frc/lib/controllers/TakeBackHalf.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/TakeBackHalf.java
@@ -1,0 +1,40 @@
+package com.pigmice.frc.lib.controllers;
+
+import com.pigmice.frc.lib.utils.Range;
+
+public class TakeBackHalf implements IController {
+    private double gain;
+    private double currentOutput;
+    private double previousError;
+    private double takeBackHalf;
+
+    private final Range outputBounds = new Range(-1.0, 1.0);
+
+    public TakeBackHalf(double gain) {
+        this.gain = gain;
+        currentOutput = 0;
+        previousError = 1;
+        takeBackHalf = 0;
+    }
+
+    public void initialize(double input, double currentOutput) {
+        this.currentOutput = currentOutput;
+        previousError = 1;
+    }
+
+    public double calculateOutput(double input, double setpoint) {
+        double error = setpoint - input;
+        currentOutput += error * gain;
+
+        if (Math.signum(previousError) != Math.signum(error)) {
+            currentOutput = 0.5 * (currentOutput + takeBackHalf);
+            takeBackHalf = currentOutput;
+        }
+
+        previousError = error;
+
+        currentOutput = outputBounds.clamp(currentOutput);
+
+        return currentOutput;
+    }
+}

--- a/src/main/java/com/pigmice/frc/lib/controllers/TakeBackHalf.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/TakeBackHalf.java
@@ -2,33 +2,44 @@ package com.pigmice.frc.lib.controllers;
 
 import com.pigmice.frc.lib.utils.Range;
 
+/**
+ * Implementation of robust and simple to tune "Take Back Half" controller,
+ * controller designed by W. Steven Woodward.
+ */
 public class TakeBackHalf implements IController {
     private double gain;
     private double currentOutput;
     private double previousError;
     private double takeBackHalf;
 
+    // Approximation of output needed to remain at setpoint
+    // Used for selecting optimum initial TBH value
+    private double targetOutput;
+
     private final Range outputBounds = new Range(-1.0, 1.0);
 
-    public TakeBackHalf(double gain) {
+    public TakeBackHalf(double gain, double targetOutput) {
         this.gain = gain;
         currentOutput = 0;
         previousError = 1;
-        takeBackHalf = 0;
+        this.targetOutput = targetOutput;
+        takeBackHalf = 2*targetOutput - 1;
     }
 
     public void initialize(double input, double currentOutput) {
         this.currentOutput = currentOutput;
         previousError = 1;
+        takeBackHalf = 2*targetOutput - 1;
     }
 
     public double calculateOutput(double input, double setpoint) {
         double error = setpoint - input;
-        currentOutput += error * gain;
 
         if (Math.signum(previousError) != Math.signum(error)) {
             currentOutput = 0.5 * (currentOutput + takeBackHalf);
             takeBackHalf = currentOutput;
+        } else {
+            currentOutput += error * gain;
         }
 
         previousError = error;

--- a/src/main/java/com/pigmice/frc/lib/inputs/Debouncer.java
+++ b/src/main/java/com/pigmice/frc/lib/inputs/Debouncer.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 /**
  * Debouncer wraps a raw boolean controller input and provides simple

--- a/src/main/java/com/pigmice/frc/lib/inputs/IBooleanSource.java
+++ b/src/main/java/com/pigmice/frc/lib/inputs/IBooleanSource.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 public interface IBooleanSource {
     public boolean get();

--- a/src/main/java/com/pigmice/frc/lib/inputs/SubstateToggle.java
+++ b/src/main/java/com/pigmice/frc/lib/inputs/SubstateToggle.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 /**
  * SubstateToggle is a control utility for toggling within another mode. For

--- a/src/main/java/com/pigmice/frc/lib/inputs/Toggle.java
+++ b/src/main/java/com/pigmice/frc/lib/inputs/Toggle.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 /**
  * Toggle is a control utility for toggling something, such as a specific

--- a/src/main/java/com/pigmice/frc/lib/motion/IProfile.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/IProfile.java
@@ -5,7 +5,6 @@ public interface IProfile {
     public double getDuration();
     public void reset();
 
-
     default double getVelocity(double time) {
         return getSetpoint(time).getVelocity();
     }

--- a/src/main/java/com/pigmice/frc/lib/motion/StaticProfile.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/StaticProfile.java
@@ -6,8 +6,8 @@ import com.pigmice.frc.lib.utils.Utils;
 
 public class StaticProfile implements IProfile {
     private final ArrayList<Chunk> chunks;
-    private double maxAccel, maxDecel, maxVelocity, startingPosition;
-    private double profileDuration, profileDistance;
+    private final double maxAccel, maxDecel, maxVelocity, startingPosition;
+    private final double duration, distance;
 
     private int currentChunk = 0;
     private double chunkEndTime, chunkStartTime, previousDistance;
@@ -24,12 +24,15 @@ public class StaticProfile implements IProfile {
 
         chunks = computeChunks(new ArrayList<Chunk>(), currentVelocity, targetDisplacement);
 
-        profileDuration = 0.0;
-        profileDistance = currentPosition;
+        double totalDuration = 0.0;
+        double totalDistance = currentPosition;
         for (Chunk chunk : chunks) {
-            profileDuration += chunk.getDuration();
-            profileDistance += chunk.getTotalDistance();
+            totalDuration += chunk.getDuration();
+            totalDistance += chunk.getTotalDistance();
         }
+
+        this.distance = totalDistance;
+        this.duration = totalDuration;
 
         previousDistance = currentPosition;
         chunk = chunks.get(0);
@@ -136,7 +139,7 @@ public class StaticProfile implements IProfile {
     }
 
     public double getDuration() {
-        return profileDuration;
+        return duration;
     }
 
     private Setpoint getEndSetpoint(double distance) {
@@ -154,8 +157,8 @@ public class StaticProfile implements IProfile {
     }
 
     public Setpoint getSetpoint(double time) {
-        if (time >= profileDuration) {
-            return getEndSetpoint(profileDistance);
+        if (time >= duration) {
+            return getEndSetpoint(distance);
         }
 
         while (time >= chunkEndTime) {

--- a/src/main/java/com/pigmice/frc/lib/motion/execution/ProfileExecutor.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/execution/ProfileExecutor.java
@@ -14,13 +14,13 @@ public class ProfileExecutor {
         double get();
     }
 
-    private IProfile profile;
-    private Output output;
-    private Input input;
-    private double startTime;
-    private double allowableError;
+    private final IProfile profile;
+    private final Output output;
+    private final Input input;
+    private final double allowableError;
+    private final double finalTarget;
 
-    private double finalTarget;
+    private double startTime;
 
     public ProfileExecutor(IProfile profile, Output output, Input input, double allowableError) {
         this.profile = profile;

--- a/src/main/java/com/pigmice/frc/lib/pidf/PIDF.java
+++ b/src/main/java/com/pigmice/frc/lib/pidf/PIDF.java
@@ -1,9 +1,11 @@
 package com.pigmice.frc.lib.pidf;
 
+import com.pigmice.frc.lib.controllers.IController;
 import com.pigmice.frc.lib.utils.Range;
 
-public class PIDF {
+public class PIDF implements IController {
     private Gains gains;
+    private final double period;
 
     private Range outputBounds;
     private Range inputBounds;
@@ -12,22 +14,17 @@ public class PIDF {
     private boolean useDerivativeOnInput;
 
     private double integralTerm;
-    private double previousTime;
     private double previousInput;
     private double previousError;
 
-    private double previousDerivative;
-
-    public PIDF(Gains gains, Range outputBounds) {
+    public PIDF(Gains gains, Range outputBounds, double period) {
         this.gains = gains;
+        this.period = period;
         this.outputBounds = outputBounds;
 
         this.integralTerm = 0.0;
-        this.previousTime = 0.0;
         this.previousInput = 0.0;
         this.previousError = 0.0;
-
-        this.previousDerivative = 0.0;
     }
 
     /**
@@ -46,45 +43,34 @@ public class PIDF {
         this.inputBounds = inputBounds;
     }
 
-    public void initialize(double input, double time, double currentOutput) {
+    public void initialize(double input, double currentOutput) {
         integralTerm = currentOutput;
-        previousTime = time;
         previousInput = input;
         previousError = 0;
-
-        previousDerivative = 0;
     }
 
-    public double calculateOutput(double input, double setpoint, double time) {
-        return calculateOutput(input, setpoint, 0.0, 0.0, time);
+    public double calculateOutput(double input, double setpoint) {
+        return calculateOutput(input, setpoint, 0.0, 0.0);
     }
 
-    public double calculateOutput(double input, double setpoint, double velocity, double acceleration, double time) {
+    public double calculateOutput(double input, double setpoint, double velocity, double acceleration) {
         double error = setpoint - input;
         if (continuous) {
             error = calculateContinuousError(error);
         }
 
-        double deltaTime = time - previousTime;
-
-        integralTerm += gains.kI() * error * deltaTime;
+        integralTerm += gains.kI() * error * period;
 
         double derivative;
-        if (deltaTime > 0.0) {
-            if (useDerivativeOnInput) {
-                double deltaInput = calculateContinuousError(input - previousInput);
-                derivative = -deltaInput / deltaTime;
-            } else {
-                derivative = (error - previousError) / deltaTime;
-            }
+        if (useDerivativeOnInput) {
+            double deltaInput = calculateContinuousError(input - previousInput);
+            derivative = -deltaInput / period;
         } else {
-            derivative = previousDerivative;
+            derivative = (error - previousError) / period;
         }
 
         previousInput = input;
         previousError = error;
-        previousTime = time;
-        previousDerivative = derivative;
 
         double feedback = gains.kP() * error + integralTerm + gains.kD() * derivative;
         double feedforward = gains.kF() * setpoint + gains.kV() * velocity + gains.kA() * acceleration;

--- a/src/test/java/com/pigmice/frc/lib/controllers/PIDGainsTest.java
+++ b/src/test/java/com/pigmice/frc/lib/controllers/PIDGainsTest.java
@@ -1,14 +1,14 @@
-package com.pigmice.frc.lib.pidf;
+package com.pigmice.frc.lib.controllers;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class GainsTest {
+public class PIDGainsTest {
     private static final double epsilon = 1e-6;
 
     @Test
     public void PIDTest() {
-        Gains gains = new Gains(1.0, 0.5, 2.0);
+        PIDGains gains = new PIDGains(1.0, 0.5, 2.0);
         Assertions.assertEquals(1.0, gains.kP(), epsilon);
         Assertions.assertEquals(0.5, gains.kI(), epsilon);
         Assertions.assertEquals(2.0, gains.kD(), epsilon);
@@ -16,7 +16,7 @@ public class GainsTest {
 
     @Test
     public void PIDFVATest() {
-        Gains gains = new Gains(-1.0, -0.5, -2.0, -0.33, 4.0, -0.1);
+        PIDGains gains = new PIDGains(-1.0, -0.5, -2.0, -0.33, 4.0, -0.1);
         Assertions.assertEquals(-1.0, gains.kP(), epsilon);
         Assertions.assertEquals(-0.5, gains.kI(), epsilon);
         Assertions.assertEquals(-2.0, gains.kD(), epsilon);

--- a/src/test/java/com/pigmice/frc/lib/controllers/PIDTest.java
+++ b/src/test/java/com/pigmice/frc/lib/controllers/PIDTest.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.pidf;
+package com.pigmice.frc.lib.controllers;
 
 import java.util.Arrays;
 import java.util.List;
@@ -9,7 +9,7 @@ import com.pigmice.frc.lib.utils.Utils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class PIDFTest {
+public class PIDTest {
     private static final double epsilon = 1e-6;
 
     private static class TestPoint {
@@ -27,12 +27,12 @@ public class PIDFTest {
         }
     }
 
-    private static void checkData(PIDF controller, List<TestPoint> testData) {
+    private static void checkData(PID controller, List<TestPoint> testData) {
         for (int i = 0; i < testData.size(); i++) {
             TestPoint datum = testData.get(i);
             double output = controller.calculateOutput(datum.input, datum.setpoint, datum.velocity, datum.acceleration);
             if (!Utils.almostEquals(datum.output, output, epsilon)) {
-                System.out.format("PIDF error, datum #%d", i + 1);
+                System.out.format("PID error, datum #%d", i + 1);
             }
             Assertions.assertEquals(datum.output, output, epsilon);
         }
@@ -40,9 +40,9 @@ public class PIDFTest {
 
     @Test
     public void positionPIDVATest() {
-        Gains gains = new Gains(2.0, 4.0, 0.5, 0.0, 1.0, 0.25);
+        PIDGains gains = new PIDGains(2.0, 4.0, 0.5, 0.0, 1.0, 0.25);
         Range outputBounds = new Range(-6.0, 6.0);
-        PIDF pidva = new PIDF(gains, outputBounds, 1.0);
+        PID pidva = new PID(gains, outputBounds, 1.0);
 
         List<TestPoint> testData = Arrays.asList(
                 // Fake profile: 6s, 18m - accel @ 3m/s for 2s, 6m/s for 1s, decel @ 3m/s for 2s
@@ -56,9 +56,9 @@ public class PIDFTest {
 
     @Test
     public void simplePIDTest() {
-        Gains gains = new Gains(1.0, 0.0, 0.0);
+        PIDGains gains = new PIDGains(1.0, 0.0, 0.0);
         Range outputBounds = new Range(-1.0, 1.0);
-        PIDF p = new PIDF(gains, outputBounds, 1.0);
+        PID p = new PID(gains, outputBounds, 1.0);
 
         p.initialize(0.0, 0.0);
         double output = p.calculateOutput(-5.0, 0.0);
@@ -67,9 +67,9 @@ public class PIDFTest {
 
     @Test
     public void ratePIFTest() {
-        Gains gains = new Gains(1.0, 0.25, 0.0, 1.0, 0.0, 0.0);
+        PIDGains gains = new PIDGains(1.0, 0.25, 0.0, 1.0, 0.0, 0.0);
         Range outputBounds = new Range(-10.0, 10.0);
-        PIDF pf = new PIDF(gains, outputBounds, 1.0);
+        PID pf = new PID(gains, outputBounds, 1.0);
 
         List<TestPoint> testData = Arrays.asList(
                 // Rate controller, shooter wheel etc. Feedforward drives output, PI adjusts it
@@ -84,9 +84,9 @@ public class PIDFTest {
 
     @Test
     public void continuousPDTest() {
-        Gains gains = new Gains(0.02, 0.0, 0.01, 0.0, 0.0, 0.0);
+        PIDGains gains = new PIDGains(0.02, 0.0, 0.01, 0.0, 0.0, 0.0);
         Range outputBounds = new Range(-2.0, 2.0);
-        PIDF pd = new PIDF(gains, outputBounds, 1.0);
+        PID pd = new PID(gains, outputBounds, 1.0);
 
         pd.setDerivativeOnInput(true);
         pd.setContinuous(new Range(10, 370), true);

--- a/src/test/java/com/pigmice/frc/lib/controllers/TakeBackHalfTest.java
+++ b/src/test/java/com/pigmice/frc/lib/controllers/TakeBackHalfTest.java
@@ -1,0 +1,18 @@
+package com.pigmice.frc.lib.controllers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TakeBackHalfTest {
+    @Test
+    public void testOutput() {
+        TakeBackHalf tbh = new TakeBackHalf(0.0002);
+
+        tbh.initialize(0.0, 0.0);
+        Assertions.assertEquals(0.4, tbh.calculateOutput(0.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.8, tbh.calculateOutput(0.0, 2000.0), 1e-6);
+        Assertions.assertEquals(1.0, tbh.calculateOutput(0.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.4, tbh.calculateOutput(3000.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.5, tbh.calculateOutput(1000.0, 2000.0), 1e-6);
+    }
+}

--- a/src/test/java/com/pigmice/frc/lib/controllers/TakeBackHalfTest.java
+++ b/src/test/java/com/pigmice/frc/lib/controllers/TakeBackHalfTest.java
@@ -6,13 +6,24 @@ import org.junit.jupiter.api.Test;
 public class TakeBackHalfTest {
     @Test
     public void testOutput() {
-        TakeBackHalf tbh = new TakeBackHalf(0.0002);
+        TakeBackHalf tbh = new TakeBackHalf(0.0002, 0.5);
 
         tbh.initialize(0.0, 0.0);
         Assertions.assertEquals(0.4, tbh.calculateOutput(0.0, 2000.0), 1e-6);
         Assertions.assertEquals(0.8, tbh.calculateOutput(0.0, 2000.0), 1e-6);
         Assertions.assertEquals(1.0, tbh.calculateOutput(0.0, 2000.0), 1e-6);
-        Assertions.assertEquals(0.4, tbh.calculateOutput(3000.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.5, tbh.calculateOutput(3000.0, 2000.0), 1e-6);
         Assertions.assertEquals(0.5, tbh.calculateOutput(1000.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.7, tbh.calculateOutput(1000.0, 2000.0), 1e-6);
+    }
+
+    @Test
+    public void testOptimalTakeBackHalf() {
+        TakeBackHalf tbh = new TakeBackHalf(0.0002, 0.5);
+
+        tbh.initialize(0.0, 1.0);
+        Assertions.assertEquals(1.0, tbh.calculateOutput(1000.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.5, tbh.calculateOutput(2500.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.48, tbh.calculateOutput(2100.0, 2000.0), 1e-6);
     }
 }

--- a/src/test/java/com/pigmice/frc/lib/inputs/DebouncerTest.java
+++ b/src/test/java/com/pigmice/frc/lib/inputs/DebouncerTest.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/pigmice/frc/lib/inputs/InputMock.java
+++ b/src/test/java/com/pigmice/frc/lib/inputs/InputMock.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 public class InputMock implements IBooleanSource {
     private boolean[] outputs;

--- a/src/test/java/com/pigmice/frc/lib/inputs/SubstateToggleTest.java
+++ b/src/test/java/com/pigmice/frc/lib/inputs/SubstateToggleTest.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/pigmice/frc/lib/inputs/ToggleTest.java
+++ b/src/test/java/com/pigmice/frc/lib/inputs/ToggleTest.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.controls;
+package com.pigmice.frc.lib.inputs;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/pigmice/frc/lib/pidf/PIDFTest.java
+++ b/src/test/java/com/pigmice/frc/lib/pidf/PIDFTest.java
@@ -15,16 +15,14 @@ public class PIDFTest {
     private static class TestPoint {
         public double input;
         private double setpoint, velocity, acceleration;
-        private double time;
         private double output;
 
-        public TestPoint(double time, double output, double input, double setpoint, double velocity,
+        public TestPoint(double output, double input, double setpoint, double velocity,
                 double acceleration) {
             this.input = input;
             this.setpoint = setpoint;
             this.velocity = velocity;
             this.acceleration = acceleration;
-            this.time = time;
             this.output = output;
         }
     }
@@ -32,8 +30,7 @@ public class PIDFTest {
     private static void checkData(PIDF controller, List<TestPoint> testData) {
         for (int i = 0; i < testData.size(); i++) {
             TestPoint datum = testData.get(i);
-            double output = controller.calculateOutput(datum.input, datum.setpoint, datum.velocity, datum.acceleration,
-                    datum.time);
+            double output = controller.calculateOutput(datum.input, datum.setpoint, datum.velocity, datum.acceleration);
             if (!Utils.almostEquals(datum.output, output, epsilon)) {
                 System.out.format("PIDF error, datum #%d", i + 1);
             }
@@ -45,15 +42,15 @@ public class PIDFTest {
     public void positionPIDVATest() {
         Gains gains = new Gains(2.0, 4.0, 0.5, 0.0, 1.0, 0.25);
         Range outputBounds = new Range(-6.0, 6.0);
-        PIDF pidva = new PIDF(gains, outputBounds);
+        PIDF pidva = new PIDF(gains, outputBounds, 1.0);
 
         List<TestPoint> testData = Arrays.asList(
                 // Fake profile: 6s, 18m - accel @ 3m/s for 2s, 6m/s for 1s, decel @ 3m/s for 2s
-                new TestPoint(0.0, 0.75, 0.0, 0.0, 0.0, 3.0), new TestPoint(1.0, 6.0, 1.0, 1.5, 3.0, 3.0),
-                new TestPoint(2.0, 6.0, 4.0, 6.0, 6.0, 0.0), new TestPoint(3.0, -6.0, 14.0, 12.0, 6.0, -3.0),
-                new TestPoint(4.0, 4.5, 15.5, 16.5, 3.0, -3.0), new TestPoint(5.0, -2.5, 18.0, 18.0, 0.0, -3.0));
+                new TestPoint(0.75, 0.0, 0.0, 0.0, 3.0), new TestPoint(6.0, 1.0, 1.5, 3.0, 3.0),
+                new TestPoint(6.0, 4.0, 6.0, 6.0, 0.0), new TestPoint(-6.0, 14.0, 12.0, 6.0, -3.0),
+                new TestPoint(4.5, 15.5, 16.5, 3.0, -3.0), new TestPoint(-2.5, 18.0, 18.0, 0.0, -3.0));
 
-        pidva.initialize(0.0, 0.0, 0.0);
+        pidva.initialize(0.0, 0.0);
         checkData(pidva, testData);
     }
 
@@ -61,10 +58,10 @@ public class PIDFTest {
     public void simplePIDTest() {
         Gains gains = new Gains(1.0, 0.0, 0.0);
         Range outputBounds = new Range(-1.0, 1.0);
-        PIDF p = new PIDF(gains, outputBounds);
+        PIDF p = new PIDF(gains, outputBounds, 1.0);
 
-        p.initialize(0.0, 0.0, 0.0);
-        double output = p.calculateOutput(-5.0, 0.0, 1.0);
+        p.initialize(0.0, 0.0);
+        double output = p.calculateOutput(-5.0, 0.0);
         Assertions.assertEquals(1.0, output, epsilon);
     }
 
@@ -72,16 +69,16 @@ public class PIDFTest {
     public void ratePIFTest() {
         Gains gains = new Gains(1.0, 0.25, 0.0, 1.0, 0.0, 0.0);
         Range outputBounds = new Range(-10.0, 10.0);
-        PIDF pf = new PIDF(gains, outputBounds);
+        PIDF pf = new PIDF(gains, outputBounds, 1.0);
 
         List<TestPoint> testData = Arrays.asList(
                 // Rate controller, shooter wheel etc. Feedforward drives output, PI adjusts it
-                new TestPoint(2.0, 10.0, 0.0, 5.0, 0.0, 0.0), new TestPoint(3.0, 9.25, 3.0, 5.0, 0.0, 0.0),
-                new TestPoint(4.0, 8.5, 4.0, 5.0, 0.0, 0.0), new TestPoint(5.0, 7.5, 5.0, 5.0, 0.0, 0.0),
-                new TestPoint(6.0, -10.0, 5.0, -5.0, 0.0, 0.0), new TestPoint(7.0, -10.0, 2.0, -5.0, 0.0, 0.0),
-                new TestPoint(8.0, -9.25, -3.0, -5.0, 0.0, 0.0), new TestPoint(9.0, -7.25, -5.0, -5.0, 0.0, 0.0));
+                new TestPoint(10.0, 0.0, 5.0, 0.0, 0.0), new TestPoint(9.25, 3.0, 5.0, 0.0, 0.0),
+                new TestPoint(8.5, 4.0, 5.0, 0.0, 0.0), new TestPoint(7.5, 5.0, 5.0, 0.0, 0.0),
+                new TestPoint(-10.0, 5.0, -5.0, 0.0, 0.0), new TestPoint(-10.0, 2.0, -5.0, 0.0, 0.0),
+                new TestPoint(-9.25, -3.0, -5.0, 0.0, 0.0), new TestPoint(-7.25, -5.0, -5.0, 0.0, 0.0));
 
-        pf.initialize(0.0, 1.0, 0.5);
+        pf.initialize(0.0, 0.5);
         checkData(pf, testData);
     }
 
@@ -89,7 +86,7 @@ public class PIDFTest {
     public void continuousPDTest() {
         Gains gains = new Gains(0.02, 0.0, 0.01, 0.0, 0.0, 0.0);
         Range outputBounds = new Range(-2.0, 2.0);
-        PIDF pd = new PIDF(gains, outputBounds);
+        PIDF pd = new PIDF(gains, outputBounds, 1.0);
 
         pd.setDerivativeOnInput(true);
         pd.setContinuous(new Range(10, 370), true);
@@ -98,12 +95,12 @@ public class PIDFTest {
                 // Continuous PD, like for swerve drive wheel angle control. Derivative on input
                 // instead of error so that large setpoint changes don't cause derivative spike
                 // Sensor input range is 10-370, and wraps around at 370 back to 10.
-                new TestPoint(0.0, -2.0, 20.0, 280.0, 0.0, 0.0), new TestPoint(1.0, -0.5, 330.0, 280.0, 0.0, 0.0),
-                new TestPoint(2.0, -0.1, 300.0, 280.0, 0.0, 0.0), new TestPoint(3.0, 0.2, 280.0, 280.0, 0.0, 0.0),
-                new TestPoint(4.0, 2.0, 280.0, 25.0, 0.0, 0.0), new TestPoint(5.0, 0.6, 330.0, 25.0, 0.0, 0.0),
-                new TestPoint(6.0, 0.05, 365.0, 25.0, 0.0, 0.0), new TestPoint(7.0, 0.25, 10.0, 25.0, 0.0, 0.0));
+                new TestPoint(-2.0, 20.0, 280.0, 0.0, 0.0), new TestPoint(-0.5, 330.0, 280.0, 0.0, 0.0),
+                new TestPoint(-0.1, 300.0, 280.0, 0.0, 0.0), new TestPoint(0.2, 280.0, 280.0, 0.0, 0.0),
+                new TestPoint(2.0, 280.0, 25.0, 0.0, 0.0), new TestPoint(0.6, 330.0, 25.0, 0.0, 0.0),
+                new TestPoint(0.05, 365.0, 25.0, 0.0, 0.0), new TestPoint(0.25, 10.0, 25.0, 0.0, 0.0));
 
-        pd.initialize(10.0, 0.0, 0.0);
+        pd.initialize(10.0, 0.0);
         checkData(pd, testData);
     }
 }


### PR DESCRIPTION
Use common controller interface for Take-Back-Half, PID, etc. This will let other code like the ProfileExecutor be able to interact with a generic controller interface.