### PR TITLE
Execute profiles using IController, ISetpoint

### DIFF
--- a/src/main/java/com/pigmice/frc/lib/controllers/IController.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/IController.java
@@ -1,6 +1,8 @@
 package com.pigmice.frc.lib.controllers;
 
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
+
 public interface IController {
     public void initialize(double input, double currentOutput);
-    public double calculateOutput(double input, double setpoint);
+    public double calculateOutput(double input, ISetpoint setpoint);
 }

--- a/src/main/java/com/pigmice/frc/lib/controllers/PID.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/PID.java
@@ -1,5 +1,6 @@
 package com.pigmice.frc.lib.controllers;
 
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
 import com.pigmice.frc.lib.utils.Range;
 
 public class PID implements IController {
@@ -48,12 +49,8 @@ public class PID implements IController {
         previousError = 0;
     }
 
-    public double calculateOutput(double input, double setpoint) {
-        return calculateOutput(input, setpoint, 0.0, 0.0);
-    }
-
-    public double calculateOutput(double input, double setpoint, double velocity, double acceleration) {
-        double error = setpoint - input;
+    public double calculateOutput(double input, ISetpoint setpoint) {
+        double error = setpoint.getPosition() - input;
         if (continuous) {
             error = calculateContinuousError(error);
         }
@@ -72,7 +69,9 @@ public class PID implements IController {
         previousError = error;
 
         double feedback = gains.kP() * error + integralTerm + gains.kD() * derivative;
-        double feedforward = gains.kF() * setpoint + gains.kV() * velocity + gains.kA() * acceleration;
+        double feedforward = gains.kF() * setpoint.getPosition() +
+                             gains.kV() * setpoint.getVelocity() +
+                             gains.kA() * setpoint.getAcceleration();
 
         double output = feedforward + feedback;
 

--- a/src/main/java/com/pigmice/frc/lib/controllers/TakeBackHalf.java
+++ b/src/main/java/com/pigmice/frc/lib/controllers/TakeBackHalf.java
@@ -1,10 +1,11 @@
 package com.pigmice.frc.lib.controllers;
 
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
 import com.pigmice.frc.lib.utils.Range;
 
 /**
  * Implementation of robust and simple to tune "Take Back Half" controller,
- * controller designed by W. Steven Woodward.
+ * controller designed by W. Steven Woodward. Velocity controller.
  */
 public class TakeBackHalf implements IController {
     private double gain;
@@ -32,8 +33,8 @@ public class TakeBackHalf implements IController {
         takeBackHalf = 2*targetOutput - 1;
     }
 
-    public double calculateOutput(double input, double setpoint) {
-        double error = setpoint - input;
+    public double calculateOutput(double input, ISetpoint setpoint) {
+        double error = setpoint.getVelocity() - input;
 
         if (Math.signum(previousError) != Math.signum(error)) {
             currentOutput = 0.5 * (currentOutput + takeBackHalf);

--- a/src/main/java/com/pigmice/frc/lib/motion/profile/Chunk.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/profile/Chunk.java
@@ -1,5 +1,7 @@
-package com.pigmice.frc.lib.motion;
+package com.pigmice.frc.lib.motion.profile;
 
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
+import com.pigmice.frc.lib.motion.setpoint.Setpoint;
 import com.pigmice.frc.lib.utils.Transition;
 
 class Chunk {
@@ -55,7 +57,7 @@ class Chunk {
         return new Chunk(distance, velocity, Transition.zero(), Transition.zero(), duration);
     }
 
-    protected Setpoint getSetpoint(double time) {
+    protected ISetpoint getSetpoint(double time) {
         return new Setpoint(getPosition(time), getVelocity(time), acceleration, getCurvature(time), getHeading(time));
     }
 

--- a/src/main/java/com/pigmice/frc/lib/motion/profile/IProfile.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/profile/IProfile.java
@@ -1,7 +1,9 @@
-package com.pigmice.frc.lib.motion;
+package com.pigmice.frc.lib.motion.profile;
+
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
 
 public interface IProfile {
-    public Setpoint getSetpoint(double time);
+    public ISetpoint getSetpoint(double time);
     public double getDuration();
     public void reset();
 

--- a/src/main/java/com/pigmice/frc/lib/motion/profile/StaticProfile.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/profile/StaticProfile.java
@@ -1,7 +1,8 @@
-package com.pigmice.frc.lib.motion;
+package com.pigmice.frc.lib.motion.profile;
 
 import java.util.ArrayList;
 
+import com.pigmice.frc.lib.motion.setpoint.Setpoint;
 import com.pigmice.frc.lib.utils.Utils;
 
 public class StaticProfile implements IProfile {
@@ -156,6 +157,14 @@ public class StaticProfile implements IProfile {
         chunkEndTime += chunk.getDuration();
     }
 
+    private static Setpoint createSetpoint(Chunk chunk, double time, double previousDistance) {
+        double position = chunk.getPosition(time) + previousDistance;
+        double velocity = chunk.getVelocity(time);
+        double acceleration = chunk.getAcceleration();
+
+        return new Setpoint(position, velocity, acceleration, 0.0, 0.0);
+    }
+
     public Setpoint getSetpoint(double time) {
         if (time >= duration) {
             return getEndSetpoint(distance);
@@ -165,6 +174,6 @@ public class StaticProfile implements IProfile {
             advanceChunk();
         }
 
-        return new Setpoint(chunk, time - chunkStartTime, previousDistance, 0.0, 0.0);
+        return createSetpoint(chunk, time - chunkStartTime, previousDistance);
     }
 }

--- a/src/main/java/com/pigmice/frc/lib/motion/setpoint/ISetpoint.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/setpoint/ISetpoint.java
@@ -1,0 +1,13 @@
+package com.pigmice.frc.lib.motion.setpoint;
+
+public interface ISetpoint {
+    double getAcceleration();
+
+    double getVelocity();
+
+    double getPosition();
+
+    double getCurvature();
+
+    double getHeading();
+}

--- a/src/main/java/com/pigmice/frc/lib/motion/setpoint/Setpoint.java
+++ b/src/main/java/com/pigmice/frc/lib/motion/setpoint/Setpoint.java
@@ -1,6 +1,6 @@
-package com.pigmice.frc.lib.motion;
+package com.pigmice.frc.lib.motion.setpoint;
 
-public class Setpoint {
+public class Setpoint implements ISetpoint{
     private final double position, velocity, acceleration;
     private final double curvature, heading;
 
@@ -8,14 +8,6 @@ public class Setpoint {
         this.acceleration = acceleration;
         this.velocity = velocity;
         this.position = position;
-        this.curvature = curvature;
-        this.heading = heading;
-    }
-
-    public Setpoint(Chunk chunk, double time, double previousDistance, double curvature, double heading) {
-        acceleration = chunk.getAcceleration();
-        velocity = chunk.getVelocity(time);
-        position = chunk.getPosition(time) + previousDistance;
         this.curvature = curvature;
         this.heading = heading;
     }
@@ -43,10 +35,10 @@ public class Setpoint {
     /***
      * Converts angular setpoint from being in terms of angle (<b>in radians</b>) to the arc length
      * distance of the robot's wheels.
-     * 
+     *
      * The arc length is the distance covered while turning
      * from 0 to the angle specified by this setpoint, using the specified turning radius.
-     * 
+     *
      * The position, velocity, and acceleration are converted from radians per time to position per
      * time. Curvature is calculated as the inverse of the turning radius, and heading is the angle.
      *
@@ -60,10 +52,10 @@ public class Setpoint {
    /***
      * Converts angular setpoint from being in terms of angle to the arc length
      * distance of the robot's wheels.
-     * 
+     *
      * The arc length is the distance covered while turning
      * from 0 to the angle specified by this setpoint, using the specified turning radius.
-     * 
+     *
      * The position, velocity, and acceleration are converted from radians/degree per time to position per
      * time. Curvature is calculated as the inverse of the turning radius, and heading is the angle.
      *
@@ -89,7 +81,7 @@ public class Setpoint {
     /**
      * Negates this setpoint. Position, velocity, and acceleration are negated, curvature and heading
      * are unchanged.
-     * 
+     *
      * @return The negated setpoint
      */
     public Setpoint negate() {

--- a/src/test/java/com/pigmice/frc/lib/controllers/PIDTest.java
+++ b/src/test/java/com/pigmice/frc/lib/controllers/PIDTest.java
@@ -3,6 +3,8 @@ package com.pigmice.frc.lib.controllers;
 import java.util.Arrays;
 import java.util.List;
 
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
+import com.pigmice.frc.lib.motion.setpoint.Setpoint;
 import com.pigmice.frc.lib.utils.Range;
 import com.pigmice.frc.lib.utils.Utils;
 
@@ -12,25 +14,45 @@ import org.junit.jupiter.api.Test;
 public class PIDTest {
     private static final double epsilon = 1e-6;
 
-    private static class TestPoint {
+    private static class TestPoint implements ISetpoint {
         public double input;
-        private double setpoint, velocity, acceleration;
+        private double position, velocity, acceleration;
         private double output;
 
-        public TestPoint(double output, double input, double setpoint, double velocity,
+        public TestPoint(double output, double input, double position, double velocity,
                 double acceleration) {
             this.input = input;
-            this.setpoint = setpoint;
+            this.position = position;
             this.velocity = velocity;
             this.acceleration = acceleration;
             this.output = output;
+        }
+
+        public double getAcceleration() {
+            return acceleration;
+        }
+
+        public double getVelocity() {
+            return velocity;
+        }
+
+        public double getPosition() {
+            return position;
+        }
+
+        public double getCurvature() {
+            return 0;
+        }
+
+        public double getHeading() {
+            return 0;
         }
     }
 
     private static void checkData(PID controller, List<TestPoint> testData) {
         for (int i = 0; i < testData.size(); i++) {
             TestPoint datum = testData.get(i);
-            double output = controller.calculateOutput(datum.input, datum.setpoint, datum.velocity, datum.acceleration);
+            double output = controller.calculateOutput(datum.input, datum);
             if (!Utils.almostEquals(datum.output, output, epsilon)) {
                 System.out.format("PID error, datum #%d", i + 1);
             }
@@ -61,7 +83,7 @@ public class PIDTest {
         PID p = new PID(gains, outputBounds, 1.0);
 
         p.initialize(0.0, 0.0);
-        double output = p.calculateOutput(-5.0, 0.0);
+        double output = p.calculateOutput(-5.0, new Setpoint(0.0, 0.0, 0.0, 0.0, 0.0));
         Assertions.assertEquals(1.0, output, epsilon);
     }
 

--- a/src/test/java/com/pigmice/frc/lib/controllers/TakeBackHalfTest.java
+++ b/src/test/java/com/pigmice/frc/lib/controllers/TakeBackHalfTest.java
@@ -1,20 +1,26 @@
 package com.pigmice.frc.lib.controllers;
 
+import com.pigmice.frc.lib.motion.setpoint.Setpoint;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TakeBackHalfTest {
+    private static Setpoint sp(double velocity) {
+        return new Setpoint(0.0, velocity, 0.0, 0.0, 0.0);
+    }
+
     @Test
     public void testOutput() {
         TakeBackHalf tbh = new TakeBackHalf(0.0002, 0.5);
 
         tbh.initialize(0.0, 0.0);
-        Assertions.assertEquals(0.4, tbh.calculateOutput(0.0, 2000.0), 1e-6);
-        Assertions.assertEquals(0.8, tbh.calculateOutput(0.0, 2000.0), 1e-6);
-        Assertions.assertEquals(1.0, tbh.calculateOutput(0.0, 2000.0), 1e-6);
-        Assertions.assertEquals(0.5, tbh.calculateOutput(3000.0, 2000.0), 1e-6);
-        Assertions.assertEquals(0.5, tbh.calculateOutput(1000.0, 2000.0), 1e-6);
-        Assertions.assertEquals(0.7, tbh.calculateOutput(1000.0, 2000.0), 1e-6);
+        Assertions.assertEquals(0.4, tbh.calculateOutput(0.0, sp(2000.0)), 1e-6);
+        Assertions.assertEquals(0.8, tbh.calculateOutput(0.0, sp(2000.0)), 1e-6);
+        Assertions.assertEquals(1.0, tbh.calculateOutput(0.0, sp(2000.0)), 1e-6);
+        Assertions.assertEquals(0.5, tbh.calculateOutput(3000.0, sp(2000.0)), 1e-6);
+        Assertions.assertEquals(0.5, tbh.calculateOutput(1000.0, sp(2000.0)), 1e-6);
+        Assertions.assertEquals(0.7, tbh.calculateOutput(1000.0, sp(2000.0)), 1e-6);
     }
 
     @Test
@@ -22,8 +28,8 @@ public class TakeBackHalfTest {
         TakeBackHalf tbh = new TakeBackHalf(0.0002, 0.5);
 
         tbh.initialize(0.0, 1.0);
-        Assertions.assertEquals(1.0, tbh.calculateOutput(1000.0, 2000.0), 1e-6);
-        Assertions.assertEquals(0.5, tbh.calculateOutput(2500.0, 2000.0), 1e-6);
-        Assertions.assertEquals(0.48, tbh.calculateOutput(2100.0, 2000.0), 1e-6);
+        Assertions.assertEquals(1.0, tbh.calculateOutput(1000.0, sp(2000.0)), 1e-6);
+        Assertions.assertEquals(0.5, tbh.calculateOutput(2500.0, sp(2000.0)), 1e-6);
+        Assertions.assertEquals(0.48, tbh.calculateOutput(2100.0, sp(2000.0)), 1e-6);
     }
 }

--- a/src/test/java/com/pigmice/frc/lib/motion/execution/ProfileExecutorTest.java
+++ b/src/test/java/com/pigmice/frc/lib/motion/execution/ProfileExecutorTest.java
@@ -3,28 +3,43 @@ package com.pigmice.frc.lib.motion.execution;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.pigmice.frc.lib.motion.Setpoint;
+import com.pigmice.frc.lib.controllers.IController;
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
+import com.pigmice.frc.lib.motion.setpoint.Setpoint;
 import com.pigmice.frc.lib.utils.Utils;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ProfileExecutorTest {
-    private boolean setpointEquals(Setpoint a, Setpoint b) {
-        return Utils.almostEquals(a.getPosition(), b.getPosition()) &&
-               Utils.almostEquals(a.getVelocity(), b.getVelocity()) &&
-               Utils.almostEquals(a.getAcceleration(), b.getAcceleration()) &&
-               Utils.almostEquals(a.getCurvature(), b.getCurvature()) &&
-               Utils.almostEquals(a.getHeading(), b.getHeading());
+    private static boolean setpointEquals(ISetpoint a, ISetpoint b) {
+        return Utils.almostEquals(a.getPosition(), b.getPosition())
+                && Utils.almostEquals(a.getVelocity(), b.getVelocity())
+                && Utils.almostEquals(a.getAcceleration(), b.getAcceleration())
+                && Utils.almostEquals(a.getCurvature(), b.getCurvature())
+                && Utils.almostEquals(a.getHeading(), b.getHeading());
+    }
+
+    private static class PassThroughController implements IController {
+        public List<ISetpoint> outputs = new ArrayList<>();
+
+        public void initialize(double input, double currentOutput) { }
+
+        public double calculateOutput(double input, ISetpoint setpoint) {
+            outputs.add(setpoint);
+            return setpoint.getPosition();
+        }
     }
 
     @Test
     public void errorTest() {
         Setpoint[] data = new Setpoint[] { new Setpoint(5.0, 2.0, 0.0, 0.0, 0.0) };
         ProfileMock profile = new ProfileMock(data, 10);
+        PassThroughController controller = new PassThroughController();
 
         List<Double> input = new ArrayList<Double>();
 
+        input.add(3.0);
         input.add(3.0);
         input.add(3.5);
         input.add(6.5);
@@ -33,8 +48,9 @@ public class ProfileExecutorTest {
         input.add(0.0);
 
         ProfileExecutor executor = new ProfileExecutor(
-            profile, (Setpoint s) -> {}, () -> input.remove(0), 1.0
+            profile, controller, (double sp) -> {}, () -> input.remove(0), 1.0
         );
+
         executor.initialize();
 
         Assertions.assertFalse(executor.update());
@@ -54,11 +70,11 @@ public class ProfileExecutorTest {
             new Setpoint(11.0, 2.0, 0.0, 0.0, 0.0)
         };
 
-        List<Setpoint> output = new ArrayList<Setpoint>();
         ProfileMock profile = new ProfileMock(data, 10);
+        PassThroughController controller = new PassThroughController();
 
         ProfileExecutor executor = new ProfileExecutor(
-            profile, (Setpoint s) -> output.add(s), () -> 3, 1.0);
+            profile, controller, (double sp) -> {}, () -> 3, 1.0);
         executor.initialize();
 
         executor.update();
@@ -66,9 +82,9 @@ public class ProfileExecutorTest {
         executor.update();
         executor.update();
 
-        Assertions.assertTrue(setpointEquals(output.get(0), data[0]));
-        Assertions.assertTrue(setpointEquals(output.get(1), data[1]));
-        Assertions.assertTrue(setpointEquals(output.get(2), data[2]));
-        Assertions.assertTrue(setpointEquals(output.get(3), data[3]));
+        Assertions.assertTrue(setpointEquals(controller.outputs.get(0), data[0]));
+        Assertions.assertTrue(setpointEquals(controller.outputs.get(1), data[1]));
+        Assertions.assertTrue(setpointEquals(controller.outputs.get(2), data[2]));
+        Assertions.assertTrue(setpointEquals(controller.outputs.get(3), data[3]));
     }
 }

--- a/src/test/java/com/pigmice/frc/lib/motion/execution/ProfileMock.java
+++ b/src/test/java/com/pigmice/frc/lib/motion/execution/ProfileMock.java
@@ -1,25 +1,25 @@
 package com.pigmice.frc.lib.motion.execution;
 
-import com.pigmice.frc.lib.motion.IProfile;
-import com.pigmice.frc.lib.motion.Setpoint;
+import com.pigmice.frc.lib.motion.profile.IProfile;
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
 
 public class ProfileMock implements IProfile {
-    private Setpoint[] data;
+    private ISetpoint[] data;
     private int current;
     private double duration;
 
-    public ProfileMock(Setpoint[] data, double duration) {
+    public ProfileMock(ISetpoint[] data, double duration) {
         this.data = data;
         this.current = 0;
         this.duration = duration;
     }
 
-    public Setpoint getSetpoint(double time) {
+    public ISetpoint getSetpoint(double time) {
         if(time == duration) {
             return data[data.length - 1];
         }
 
-        Setpoint sp = data[current];
+        ISetpoint sp = data[current];
         current = (current + 1) % data.length;
         return sp;
     }

--- a/src/test/java/com/pigmice/frc/lib/motion/profile/ChunkTest.java
+++ b/src/test/java/com/pigmice/frc/lib/motion/profile/ChunkTest.java
@@ -1,4 +1,6 @@
-package com.pigmice.frc.lib.motion;
+package com.pigmice.frc.lib.motion.profile;
+
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -115,7 +117,7 @@ public class ChunkTest {
     @Test
     public void setpointTest() {
         Chunk chunk = Chunk.createVelocityTransition(-5.0, -11.0, 2.0, 3.0);
-        Setpoint sp = chunk.getSetpoint(1.0);
+        ISetpoint sp = chunk.getSetpoint(1.0);
         Assertions.assertEquals(-6.0, sp.getPosition(), epsilon);
         Assertions.assertEquals(-7.0, sp.getVelocity(), epsilon);
         Assertions.assertEquals(-2.0, sp.getAcceleration(), epsilon);

--- a/src/test/java/com/pigmice/frc/lib/motion/profile/StaticProfileTest.java
+++ b/src/test/java/com/pigmice/frc/lib/motion/profile/StaticProfileTest.java
@@ -1,5 +1,6 @@
-package com.pigmice.frc.lib.motion;
+package com.pigmice.frc.lib.motion.profile;
 
+import com.pigmice.frc.lib.motion.setpoint.Setpoint;
 import com.pigmice.frc.lib.plots.TimePlot;
 
 import org.junit.jupiter.api.AfterAll;

--- a/src/test/java/com/pigmice/frc/lib/motion/setpoint/SetpointTest.java
+++ b/src/test/java/com/pigmice/frc/lib/motion/setpoint/SetpointTest.java
@@ -1,4 +1,4 @@
-package com.pigmice.frc.lib.motion;
+package com.pigmice.frc.lib.motion.setpoint;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -14,17 +14,6 @@ public class SetpointTest {
         Assertions.assertEquals(20.0, sp.getPosition(), epsilon);
         Assertions.assertEquals(2.0, sp.getCurvature(), epsilon);
         Assertions.assertEquals(Math.PI / 2.0, sp.getHeading(), epsilon);
-    }
-
-    @Test
-    public void chunkConstructor() {
-        Chunk chunk = Chunk.createConstantVelocity(5.0, 50.0);
-        Setpoint sp = new Setpoint(chunk, 5.0, 5.0, 0.0, 0.0);
-        Assertions.assertEquals(0.0, sp.getAcceleration(), epsilon);
-        Assertions.assertEquals(5.0, sp.getVelocity(), epsilon);
-        Assertions.assertEquals(30.0, sp.getPosition(), epsilon);
-        Assertions.assertEquals(0.0, sp.getCurvature(), epsilon);
-        Assertions.assertEquals(0.0, sp.getHeading(), epsilon);
     }
 
     @Test

--- a/src/test/java/com/pigmice/frc/lib/plots/ProfilePlot.java
+++ b/src/test/java/com/pigmice/frc/lib/plots/ProfilePlot.java
@@ -1,6 +1,6 @@
 package com.pigmice.frc.lib.plots;
 
-import com.pigmice.frc.lib.motion.Setpoint;
+import com.pigmice.frc.lib.motion.setpoint.ISetpoint;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.plot.PlotOrientation;
@@ -16,7 +16,7 @@ public class ProfilePlot extends Plot {
      * Data source for a series to plot.
      */
     public interface Data {
-        Setpoint get(double time);
+        ISetpoint get(double time);
     }
 
     /**
@@ -37,7 +37,7 @@ public class ProfilePlot extends Plot {
         XYSeries position = new XYSeries("Position", false);
 
         for (double i = 0.0; i < duration; i += step) {
-            Setpoint sp = data.get(i);
+            ISetpoint sp = data.get(i);
             acceleration.add(i, sp.getAcceleration());
             velocity.add(i, sp.getVelocity());
             position.add(i, sp.getPosition());


### PR DESCRIPTION
Rather than passing only the fetching of Setpoints to the ProfileExecutor, the profile executor now uses a controller to directly process the Setpoints (which are now ISetpoints to make testing easier).