### PR TITLE
Adds maximum final speed to ProfileExecutor

### DIFF
--- a/src/main/java/com/pigmice/frc/lib/purepursuit/Path.java
+++ b/src/main/java/com/pigmice/frc/lib/purepursuit/Path.java
@@ -61,6 +61,7 @@ public class Path {
             final double endVelocity = velocities.get(i + 1);
 
             final Vector delta = end.subtract(start);
+
             if(delta.getMagnitude() < 1e-6) {
                 continue;
             }
@@ -68,6 +69,10 @@ public class Path {
             final List<Double> intersections = Utils.circleLineIntersections(start, delta, position, lookAhead);
 
             intersections.removeIf((Double x) -> (x < 0.0 || x > 1.0));
+
+            if(intersections.size() == 0 && i == positions.size() - 2 && searchStart.segment == i) {
+                return new Target(end, endVelocity, i);
+            }
 
             if (intersections.size() == 0) {
                 continue;

--- a/src/main/java/com/pigmice/frc/lib/purepursuit/PurePursuit.java
+++ b/src/main/java/com/pigmice/frc/lib/purepursuit/PurePursuit.java
@@ -7,8 +7,8 @@ import com.pigmice.frc.lib.utils.Vector;
 
 public class PurePursuit {
     public static class Output {
-        final double velocity;
-        final double curvature;
+        public final double velocity;
+        public final double curvature;
 
         public Output(double velocity, double curvature) {
             this.velocity = velocity;

--- a/src/main/java/com/pigmice/frc/lib/utils/Odometry.java
+++ b/src/main/java/com/pigmice/frc/lib/utils/Odometry.java
@@ -76,6 +76,7 @@ public class Odometry {
             double deltaY = distance * Math.sin(angle);
             pose.x += deltaX;
             pose.y += deltaY;
+            pose.heading = angle;
 
             return;
         }

--- a/src/test/java/com/pigmice/frc/lib/purepursuit/PathTest.java
+++ b/src/test/java/com/pigmice/frc/lib/purepursuit/PathTest.java
@@ -71,6 +71,13 @@ public class PathTest {
         Assertions.assertEquals(5.0, target.position.getX(), epsilon);
         Assertions.assertEquals(30.0, target.position.getY(), epsilon);
         Assertions.assertEquals(1.0, target.velocity, epsilon);
+
+        target = path.findTarget(new Point(2.0, 30.0), 5.0,
+                path.new Target(new Point(2.0, 30.0), 1.0, 3));
+
+        Assertions.assertEquals(0.0, target.position.getX(), epsilon);
+        Assertions.assertEquals(30.0, target.position.getY(), epsilon);
+        Assertions.assertEquals(0.0, target.velocity, epsilon);
     }
 
     @Test

--- a/src/test/java/com/pigmice/frc/lib/purepursuit/PurePursuitTest.java
+++ b/src/test/java/com/pigmice/frc/lib/purepursuit/PurePursuitTest.java
@@ -63,13 +63,13 @@ public class PurePursuitTest {
 
     @Test
     public void fullyOffPathTest() {
-        Path path = new Path(List.of(new Point(-5.0, 10.0), new Point(5.0, 10.0)),
-                             List.of(5.0, 0.0));
+        Path path = new Path(List.of(new Point(-5.0, 10.0), new Point(5.0, 10.0), new Point(6.0, 10.0)),
+                             List.of(5.0, 1.0, 0.0));
 
         PurePursuit controller = new PurePursuit(path);
 
         Output output = controller.process(new Pose(0.0, 0.0, 0.5*Math.PI), 9.0);
-        Assertions.assertEquals(2.5, output.velocity, epsilon);
+        Assertions.assertEquals(3.0, output.velocity, epsilon);
         Assertions.assertEquals(0.0, output.curvature, epsilon);
     }
 }

--- a/src/test/java/com/pigmice/frc/lib/utils/OdometryTest.java
+++ b/src/test/java/com/pigmice/frc/lib/utils/OdometryTest.java
@@ -89,4 +89,20 @@ public class OdometryTest {
         Assertions.assertEquals(5.0, odometer.getPose().getY(), epsilon);
         Assertions.assertEquals(-1.5 * Math.PI, odometer.getPose().getHeading(), epsilon);
     }
+
+    @Test
+    public void flipTest() {
+        Pose startingPose = new Pose(0.0, 0.0, 0.5 * Math.PI);
+        Odometry odometer = new Odometry(startingPose);
+
+        Assertions.assertEquals(0.0, odometer.getPose().getX(), epsilon);
+        Assertions.assertEquals(0.0, odometer.getPose().getY(), epsilon);
+        Assertions.assertEquals(0.5 * Math.PI, odometer.getPose().getHeading(), epsilon);
+
+        odometer.update(10.0, 10.0, 2.5 * Math.PI);
+
+        Assertions.assertEquals(0.0, odometer.getPose().getX(), epsilon);
+        Assertions.assertEquals(10.0, odometer.getPose().getY(), epsilon);
+        Assertions.assertEquals(2.5 * Math.PI, odometer.getPose().getHeading(), epsilon);
+    }
 }


### PR DESCRIPTION
Adds a parameter for the maximum speed the input can be
changing at for the ProfileExecutor to end.

Also set final path target to end of path
Fix odometry bug where heading wouldn't be updated when driving straight